### PR TITLE
Restore Dash Pump Manager after App Restart

### DIFF
--- a/OmniBLE/Info.plist
+++ b/OmniBLE/Info.plist
@@ -21,7 +21,7 @@
 	<key>com.loopkit.Loop.PumpManagerDisplayName</key>
 	<string>Omnipod Dash</string>
 	<key>com.loopkit.Loop.PumpManagerIdentifier</key>
-	<string>Omnipod Dash</string>
+	<string>Omnipod-Dash</string>
 	<key>NSPrincipalClass</key>
 	<string>OmniBLE.OmnipodPlugin</string>
 </dict>


### PR DESCRIPTION
I believe the pump identifier needs to align in Info.plist and the OmnipodPumpManager class as that string is used to restore the manager on startup.