### PR TITLE
Handle Crash From Block Running on Wrong Thread

### DIFF
--- a/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -507,12 +507,10 @@ extension CBPeripheral {
 extension PeripheralManager {
     public func runSession(withName name: String , _ block: @escaping () -> Void) {
         self.log.default("Scheduling session %{public}@", name)
-        sessionQueue.addOperation(self.configureAndRun({ [weak self] (manager) in
-            manager.perform { _ in
-                self?.log.default("======================== %{public}@ ===========================", name)
-                block()
-                self?.log.default("------------------------ %{public}@ ---------------------------", name)
-            }
-        }))
+        self.perform { [weak self] (manager) in
+            self?.log.default("======================== %{public}@ ===========================", name)
+            block()
+            self?.log.default("------------------------ %{public}@ ---------------------------", name)
+        }
     }
 }

--- a/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -507,10 +507,12 @@ extension CBPeripheral {
 extension PeripheralManager {
     public func runSession(withName name: String , _ block: @escaping () -> Void) {
         self.log.default("Scheduling session %{public}@", name)
-        self.perform { [weak self] (manager) in
-            self?.log.default("======================== %{public}@ ===========================", name)
-            block()
-            self?.log.default("------------------------ %{public}@ ---------------------------", name)
-        }
+        sessionQueue.addOperation({ [weak self] in
+            self?.perform { (manager) in
+                manager.log.default("======================== %{public}@ ===========================", name)
+                block()
+                manager.log.default("------------------------ %{public}@ ---------------------------", name)
+            }
+        })
     }
 }


### PR DESCRIPTION
Calls to configureAndRun need to currently be done on the `queue` since that hits areas of code protected by queue assertions.  This seems like a simple fix by just removing the call to `configureAndRun`, since the call to perform() already calls `configureAndRun` on the queue.

![Screen Shot 2021-12-03 at 6 12 58 AM](https://user-images.githubusercontent.com/3207996/144612313-3fa8400a-8e98-4b4c-a9b4-2f471dc7790f.jpg)


