### PR TITLE
Use timeout with thread lock

### DIFF
--- a/OmniBLE/Bluetooth/PeripheralManager+Omnipod.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+Omnipod.swift
@@ -135,8 +135,8 @@ extension PeripheralManager {
         
         // Wait for data to be read.
         queueLock.lock()
-        while (cmdQueue.count == 0) {
-            queueLock.wait()
+        if (cmdQueue.count == 0) {
+            queueLock.wait(until: Date().addingTimeInterval(timeout))
         }
         queueLock.unlock()
 
@@ -176,8 +176,8 @@ extension PeripheralManager {
         
         // Wait for data to be read.
         queueLock.lock()
-        while (dataQueue.count == 0) {
-            queueLock.wait()
+        if (dataQueue.count == 0) {
+            queueLock.wait(until: Date().addingTimeInterval(timeout))
         }
         queueLock.unlock()
 


### PR DESCRIPTION
When an error occurs communicating with the pump, the thread seemed blocked from returning. This should repsect the timeouts that are passed by the client.