### PR TITLE
Fix Packet issue

### DIFF
--- a/OmniBLE/Bluetooth/Packet/BLEPacket.swift
+++ b/OmniBLE/Bluetooth/Packet/BLEPacket.swift
@@ -154,7 +154,7 @@ struct LastOptionalPlusOneBlePacket: BlePacket {
     let size: UInt8
 
     func toData() -> Data {
-        return Data([index, size]) + payload + Data([UInt8(MAX_SIZE - payload.count - 2)]) + Data(count: MAX_SIZE - payload.count - LastOptionalPlusOneBlePacket.HEADER_SIZE - 1)
+        return Data([index, size]) + payload + Data(count: MAX_SIZE - payload.count - 2)
     }
 
     static func parse(payload: Data) throws -> LastOptionalPlusOneBlePacket {


### PR DESCRIPTION
This should fix an issue where the BLEPacket was including the wrong data. Changing this got Android to match up with iOS including the padding.